### PR TITLE
Remove direct dependency on jQuery

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "classnames": "^2.1.2",
-    "jquery": "^3.1.0",
     "metrics-graphics": "^2.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
jQuery is currently an implicit dependency because of our use of
metricsgraphics, but there's no reason for us to declare that we
need it as well (none of our code uses it).